### PR TITLE
update payoff matrix

### DIFF
--- a/models.py
+++ b/models.py
@@ -132,7 +132,7 @@ class Player(BasePlayer):
         print('in set payoffs')
         print(self.participant.payoff)
         print(self.round_payoff)
-        self.participant.payoff += self.round_payoff
+        self.participant.payoff = self.round_payoff
         print(self.participant.payoff)
     
     # quiz question after the instruction and before the practice round. general quiz.  


### PR DESCRIPTION
Hi Ryan,

I think under the current set_payoff function, the round payoff is calculated twice.
Participant.payoff = sum of player.payoff in all rounds.
We choose player.payoff in one round = a positive number so the participant.payoff already includes that round payoff.
Letting participant.payoff += player.payoff add it twice.
I think we either let participant.payoff = player.payoff or simply remove this line. What do you think?

Can you also check calculation of round_payoff in swap and token treatments, especially when the transaction is cancelled. In the pilot session today there seems to be some problem with the payoff calculation.


Best,
Shuchen